### PR TITLE
Fix content script crash when #root is missing

### DIFF
--- a/chrome/app.js
+++ b/chrome/app.js
@@ -198,7 +198,10 @@ function handleRedirect(redirectTo, url, openInNewTab) {
 // Show the links on the page
 function displayMenuOptions(url) {
   // check if it is a page
-  const root = document.getElementById('root');
+  const root = document.getElementById('root') || document.body;
+  if (!root) {
+    return;
+  }
   root.style.position = 'relative';
 
   if (checkValidURLAndShouldProceed(url)) {
@@ -325,4 +328,3 @@ function checkUserProfile(currentPath) {
   }
   return false;
 }
-

--- a/firefox/app.js
+++ b/firefox/app.js
@@ -198,7 +198,10 @@ function handleRedirect(redirectTo, url, openInNewTab) {
 // Show the links on the page
 function displayMenuOptions(url) {
   // check if it is a page
-  const root = document.getElementById('root');
+  const root = document.getElementById('root') || document.body;
+  if (!root) {
+    return;
+  }
   root.style.position = 'relative';
 
   if (checkValidURLAndShouldProceed(url)) {

--- a/tests/app.test.mjs
+++ b/tests/app.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import test from 'node:test';
+import vm from 'node:vm';
+
+function createElement(tagName) {
+  return {
+    tagName,
+    children: [],
+    style: {},
+    setAttribute(name, value) {
+      this[name] = value;
+    },
+    appendChild(child) {
+      this.children.push(child);
+    },
+  };
+}
+
+function loadScript(path, root = null) {
+  const code = fs.readFileSync(path, 'utf8');
+  const elements = new Map();
+  if (root) {
+    elements.set('root', root);
+  }
+  const sandbox = {
+    URL,
+    console: { log() {} },
+    window: { location: { href: 'https://example.com/post' } },
+    location: { href: 'https://example.com/post' },
+    sessionStorage: {
+      getItem() { return null; },
+      setItem() {},
+    },
+    MutationObserver: class {
+      observe() {}
+    },
+    document: {
+      URL: 'https://example.com/post',
+      querySelectorAll() { return []; },
+      querySelector() { return null; },
+      getElementById(id) { return elements.get(id) || null; },
+      createElement,
+    },
+  };
+  vm.runInNewContext(code, sandbox, { filename: path });
+  return sandbox;
+}
+
+for (const scriptPath of ['chrome/app.js', 'firefox/app.js']) {
+  test(`${scriptPath} displayMenuOptions tolerates pages without #root`, () => {
+    const sandbox = loadScript(scriptPath);
+
+    assert.doesNotThrow(() => {
+      sandbox.displayMenuOptions('https://example.com/post');
+    });
+  });
+
+  test(`${scriptPath} displayMenuOptions still appends menu into #root`, () => {
+    const root = createElement('div');
+    const sandbox = loadScript(scriptPath, root);
+
+    sandbox.displayMenuOptions('https://example.com/post');
+
+    assert.equal(root.style.position, 'relative');
+    assert.equal(root.children.length, 1);
+    assert.equal(root.children[0].id, 'medium-parser');
+  });
+}


### PR DESCRIPTION
## Summary
- Fall back to `document.body` when Medium Parser cannot find a `#root` container.
- Return early if neither container is available, instead of throwing from the content script.
- Add a zero-dependency Node regression test for the Chrome and Firefox content scripts.

## Why
`displayMenuOptions()` currently assumes every supported page has an element with `id="root"`. When the content script detects a Medium-like page without that container, it throws `Cannot read properties of null (reading 'style')` before rendering the parser menu. Falling back to `document.body` keeps the extension working on pages with different root markup.

## Validation
- `node --test tests/app.test.mjs` (`4 passed`)
- `node --check chrome/app.js`
- `node --check firefox/app.js`
- `node --check chrome/background.js`
- `node --check firefox/background.js`
- `node --check chrome/options.js`
- `node --check firefox/options.js`
- `git diff --check`