### PR TITLE
[codex] open options page only on first install

### DIFF
--- a/chrome/background.js
+++ b/chrome/background.js
@@ -31,8 +31,11 @@ chrome.action.onClicked.addListener(function (tab) {
 });
 
 
-chrome.runtime.onInstalled.addListener(function () {
-  chrome.tabs.create({ url: 'options.html' });
+chrome.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === 'install') {
+    chrome.tabs.create({ url: 'options.html' });
+  }
+
   chrome.contextMenus.create({
     id: parentMenuId,
     title: 'Medium Parser',

--- a/firefox/background.js
+++ b/firefox/background.js
@@ -30,8 +30,11 @@ browser.action.onClicked.addListener(function (tab) {
   browser.tabs.create({ url: 'options.html' });
 });
 
-browser.runtime.onInstalled.addListener(function () {
-  browser.tabs.create({ url: 'options.html' });
+browser.runtime.onInstalled.addListener(function (details) {
+  if (details.reason === 'install') {
+    browser.tabs.create({ url: 'options.html' });
+  }
+
   browser.contextMenus.create({
     id: parentMenuId,
     title: 'Medium Parser',


### PR DESCRIPTION
## Summary
- only open `options.html` automatically when the extension is first installed
- keep context menu creation running from the install/update listener
- apply the same behavior to Chrome and Firefox builds

## Root cause
The background scripts opened the options page unconditionally from `runtime.onInstalled`, so extension updates could show the settings page again even when the user did not ask for it.

## Validation
- `git diff --check`
- `node --test tests/app.test.mjs`
- VM smoke check for Chrome and Firefox background scripts: update does not open options, install still opens options

Fixes #41